### PR TITLE
patch for multple expressions

### DIFF
--- a/src/RCall.jl
+++ b/src/RCall.jl
@@ -51,7 +51,7 @@ SXPtype(s::SEXP{22}) = :EXTPTRSXP     # external pointer
 SXPtype(s::SEXP{23}) = :WEAKREFSXP    # weak references
 SXPtype(s::SEXP{24}) = :RAWSXP        # raw bytes
 SXPtype(s::SEXP{25}) = :S4SXP          # S4 non-vector
- 
+
 function __init__()
     argv = ["Rembed","--silent"]
     i = ccall((:Rf_initEmbeddedR,libR),Cint,(Cint,Ptr{Ptr{Uint8}}),length(argv),argv)
@@ -76,7 +76,7 @@ function Base.getindex(s::SEXP{19},I::Integer)
     asSEXP(ccall((:VECTOR_ELT,libR),Ptr{Void},(Ptr{Void},Cint),s.p,I-1))
 end
 
-for N in [10,13:16,19]                  # only vector types of SEXP's have a length
+for N in [10,13:16,19,20]                  # only vector types of SEXP's have a length
     @eval Base.length(s::SEXP{$N}) = unsafe_load(convert(Ptr{Cint},s.p+loffset),1)
 end
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -34,7 +34,11 @@ end
 
 @doc "expression objects (the result of Rparse) have a special Reval method"->
 function Reval(expr::SEXP{20}, env::SEXP{4}) # evaluate result of R_ParseVector
-    Reval(asSEXP(ccall((:VECTOR_ELT,libR),Ptr{Void},(Ptr{Void},Int),expr,0)),env)
+    local val
+    for I in 1:length(expr)
+        val = Reval(asSEXP(ccall((:VECTOR_ELT,libR),Ptr{Void},(Ptr{Void},Int),expr,I-1)),env)
+    end
+    val
 end
 Reval(s::SEXP) = Reval(s,globalEnv)
 Reval(sym::Symbol) = Reval(install(string(sym)),globalEnv)


### PR DESCRIPTION
If an expression contains multiple expressions, we should not only only evaluate the first expression.

```
julia> using RCall

julia> Reval(Rparse("a=1;b=2"))
RCall.SEXP{14}(Ptr{Void} @0x00007fbc8356fcf8)

julia> R.str(Reval(:a))
 num 1
RCall.SEXP{0}(Ptr{Void} @0x00007fbc86813b78)

julia> R.str(Reval(:b))
Error: object 'b' not found
```