### PR TITLE
add ReleaseObject and PreserveObject to protect memory from GC

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -141,3 +141,8 @@ unprotect(k::Integer) = ccall((:Rf_unprotect,libR),Void,(Cint,),k)
 @doc "unprotect an SEXP"->
 unprotect(s::SEXP) = ccall((:Rf_unprotect_ptr,libR),Void,(Ptr{Void},),s.p)
 
+@doc "release an SEXP"->
+ReleaseObject(s::SEXP) = ccall((:R_ReleaseObject,libR),Void,(Ptr{Void},),s.p)
+
+@doc "preserve an SEXP"->
+PreserveObject(s::SEXP) = ccall((:R_PreserveObject,libR),Void,(Ptr{Void},),s.p)


### PR DESCRIPTION
It is important when memory of an R object is referenced by a julia variable.

```
using RCall
x = Reval(Rparse("x = 1:10^8"))
RCall.PreserveObject(x)
y = RCall.rawvector(x);
Reval(Rparse("x = 1"))
for(i in 1:10) 
    Reval(Rparse("gc()"));
end
y
```

without the `RCall.PreserveObject` statement, the last `y` will produce segfault.