### PR TITLE
patch #8: in v0.3.x, converters are not constructor

### DIFF
--- a/src/RCall.jl
+++ b/src/RCall.jl
@@ -44,7 +44,7 @@ function __init__()
     global const nilValue = asSEXP(unsafe_load(cglobal((:R_NilValue,libR),Ptr{Void}),1))
     rone = scalarReal(1.)
     ## offsets (in bytes) from the Ptr{Void} to an R object and its vector contents
-    global const voffset = Int(ccall((:REAL,libR),Ptr{Void},(Ptr{Void},),rone) - rone.p)
+    global const voffset = int(ccall((:REAL,libR),Ptr{Void},(Ptr{Void},),rone) - rone.p)
     ## offsets (in bytes) from the Ptr{Void} to an R object and its length
     global const loffset = voffset - 2*sizeof(Cint)
 end


### PR DESCRIPTION
see #8 
In v0.4, all converters are constructor, but not in v0.3.
[see here](https://github.com/JuliaLang/julia/blob/2fdaf10d3abf5189d60dc70cd9829e4b9ecfaf76/base/base.jl#L35)

So `Int(1.0)` is fine on v0.4, but not in v0.3.