### PR TITLE
bugfix for sexp(::Matrix) the num of elements to copy was not correctly ...

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -76,17 +76,17 @@ lang3(s1::SEXP,s2::SEXP,s3::SEXP) =
 
 @doc "Create a 3-argument function call from a symbol and the arguments"->
 lang4(s1::SEXP,s2::SEXP,s3::SEXP,s4::SEXP) =
-    sexp(ccall((:Rf_lang3,libR),Ptr{Void},
+    sexp(ccall((:Rf_lang4,libR),Ptr{Void},
                  (Ptr{Void},Ptr{Void},Ptr{Void},Ptr{Void}),s1,s2,s3,s4))
 
 @doc "Create a 4-argument function call from a symbol and the arguments"->
 lang5(s1::SEXP,s2::SEXP,s3::SEXP,s4::SEXP,s5::SEXP) =
-    sexp(ccall((:Rf_lang3,libR),Ptr{Void},
+    sexp(ccall((:Rf_lang5,libR),Ptr{Void},
                  (Ptr{Void},Ptr{Void},Ptr{Void},Ptr{Void},Ptr{Void}),s1,s2,s3,s4,s5))
 
 @doc "Create a 5-argument function call from a symbol and the arguments"->
 lang6(s1::SEXP,s2::SEXP,s3::SEXP,s4::SEXP,s5::SEXP,s6::SEXP) =
-    sexp(ccall((:Rf_lang3,libR),Ptr{Void},
+    sexp(ccall((:Rf_lang6,libR),Ptr{Void},
                  (Ptr{Void},Ptr{Void},Ptr{Void},Ptr{Void},Ptr{Void},Ptr{Void}),
                  s1,s2,s3,s4,s5,s6))
 

--- a/src/sexp.jl
+++ b/src/sexp.jl
@@ -126,7 +126,7 @@ for (typ,rnm,tag,rtyp) in ((:Bool,:Logical,LGLSXP,:Int32),
         function sexp{T<:$typ}(m::Matrix{T})
             p,q = size(m)
             vv = sexp(ccall((:Rf_allocMatrix,libR),Ptr{Void},(Cint,Cint,Cint),$tag,p,q))
-            copy!(pointer_to_array(convert(Ptr{$rtyp},vv.p+voffset),l),m)
+            copy!(pointer_to_array(convert(Ptr{$rtyp},vv.p+voffset),p*q),m)
             preserve(vv)
         end
         function sexp{T<:$typ}(a::Array{T,3})


### PR DESCRIPTION
...calculated

Only fixed for 2-dim case though. Seems to be wrong also for higher dim cases so should be fixed later...