### PR TITLE
allow to import an R library as module and call functions in the module

### DIFF
--- a/src/RCall.jl
+++ b/src/RCall.jl
@@ -13,6 +13,7 @@ module RCall
            isTs,
            libR,
            named,
+           rcall,
            rcopy,
            reval,
            rparse,
@@ -66,5 +67,6 @@ end
     include("sexp.jl")
     include("iface.jl")
     include("show.jl")
+    include("functions.jl")
 
 end # module

--- a/src/RCall.jl
+++ b/src/RCall.jl
@@ -18,7 +18,9 @@ module RCall
            reval,
            rparse,
            rprint,
-           sexp
+           sexp,
+           @rimport,
+           @rusing
 
 
     if isfile(joinpath(dirname(@__FILE__),"..","deps","deps.jl"))
@@ -68,5 +70,6 @@ end
     include("iface.jl")
     include("show.jl")
     include("functions.jl")
+    include("library.jl")
 
 end # module

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -1,0 +1,23 @@
+@doc "Create a function call from a vector of the arguments"->
+function lang(f::SEXPREC,args...;kwargs...)
+    argn = length(args)+length(kwargs)
+    l = preserve(sexp(ccall((:Rf_allocVector,libR),Ptr{Void},(Cint,Int),6,argn+1)))
+    s = l.p
+    ccall((:SETCAR,libR),Ptr{Void},(Ptr{Void},Ptr{Void}),s,f)
+    for argv in args
+        typeof(argv) <: SEXPREC || throw(MethodError())
+        s = ccall((:CDR,libR),Ptr{Void},(Ptr{Void},),s)
+        ccall((:SETCAR,libR),Ptr{Void},(Ptr{Void},Ptr{Void}),s,argv)
+    end
+    for (key,argv) in kwargs
+        typeof(argv) <: SEXPREC || throw(MethodError())
+        s = ccall((:CDR,libR),Ptr{Void},(Ptr{Void},),s)
+        ccall((:SET_TAG,libR),Ptr{Void},(Ptr{Void},Ptr{Void}),s,sexp(key))
+        ccall((:SETCAR,libR),Ptr{Void},(Ptr{Void},Ptr{Void}),s,argv)
+    end
+    l
+end
+
+@doc "Evaluate the function in the global environment"->
+rcall(f::Union(SymSxp,RFunction),args...;kwargs...) = reval(lang(f,args...,kwargs...))
+rcall(f::Symbol,args...;kwargs...) = rcall(sexp(f),args...,kwargs...)

--- a/src/library.jl
+++ b/src/library.jl
@@ -1,0 +1,57 @@
+## a list of reserved names from PyCall.jl
+const reserved = Set{ASCIIString}()
+for w in ("while", "if", "for", "try", "return", "break",
+          "continue", "function", "macro", "quote", "let", "local",
+          "global", "const", "abstract", "typealias", "type",
+          "bitstype", "immutable", "ccall", "do", "module",
+          "baremodule", "using", "import", "export", "importall",
+          "pymember", "false", "true")
+    push!(reserved, w) # construct Set this way for compat with Julia 0.2/0.3
+end
+
+function rwrap(pkg::ASCIIString,s::Symbol)
+    reval("library($pkg)")
+    env = rcall(symbol("as.environment"),sexp("package:$pkg"))
+    !isNull(env) || error("The package has nothing!")
+    members = [(n, reval(env[symbol(n)])) for n in rcopy(rcall(:ls,env))]
+    filter!(x -> !(x[1] in reserved), members)
+    m = Module(s)
+    consts = [Expr(:const, Expr(:(=), symbol(x[1]), x[2])) for x in members]
+    id = Expr(:(=), :__package__, pkg)
+    exports = [symbol(x[1]) for x in members]
+    eval(m, Expr(:toplevel, consts..., Expr(:export, exports...), id))
+    m
+end
+
+macro rimport(x, args...)
+    if length(args)==2 && args[1] == :as
+        m = args[2]
+    elseif length(args)==0
+        m = x
+    else
+        throw(ArgumentError("invalid import syntax."))
+    end
+    pkg = string(x)
+    sym = Expr(:quote, m)
+    quote
+        if !isdefined($sym)
+            const $(esc(m)) = rwrap($pkg, $sym)
+            nothing
+        elseif typeof($(esc(m))) <: Module &&
+                    :__package__ in names($(esc(m)), true) &&
+                    $(esc(m)).__package__ == $pkg
+            nothing
+        else
+            error("$($sym) already exists!")
+            nothing
+        end
+    end
+end
+
+macro rusing(x)
+    sym = Expr(:quote, x)
+    quote
+        @rimport $(esc(x))
+        eval(current_module(), Expr(:using, :., $sym))
+    end
+end


### PR DESCRIPTION
A quick example of importing `MASS` and calling `ginv` function.
```
julia> @rimport MASS as m
julia> rcopy(rcall(m.ginv, sexp([1 2;2 4])))
2x2 Array{Float64,2}:
 0.04  0.08
 0.08  0.16
```