### PR TITLE
export package contents as LangSxp and make them callable in v0.4.x

### DIFF
--- a/src/functions.jl
+++ b/src/functions.jl
@@ -1,5 +1,5 @@
 @doc "Create a function call from a list of arguments"->
-function lang(f::Union(RFunction,SymSxp),args...;kwargs...)
+function lang(f::SEXPREC,args...;kwargs...)
     argn = length(args)+length(kwargs)
     l = preserve(sexp(ccall((:Rf_allocVector,libR),Ptr{Void},(Cint,Int),6,argn+1)))
     s = l.p
@@ -29,4 +29,5 @@ lang(s::Symbol,args...;kwargs...) = lang(sexp(s),args...;kwargs...)
 Evaluate a function in the global environment. The first argument corresponds
 to the function to be called. It can be either a RFunction type, a SymSxp or
 a Symbol."""->
-rcall(f::Union(RFunction,SymSxp,Symbol),args...;kwargs...) = reval(lang(f,args...,kwargs...))
+rcall(f::SEXPREC,args...;kwargs...) = reval(lang(f,args...,kwargs...))
+rcall(f::Symbol,args...;kwargs...) = reval(lang(f,args...,kwargs...))

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -8,7 +8,7 @@ function lang(f::SEXPREC,args...;kwargs...)
         if typeof(argv) <: Symbol
             argv = sexp(argv)
         end
-        typeof(argv) <: SEXPREC || throw(MethodError("expect SEXPREC arguments"))
+        typeof(argv) <: SEXPREC || throw(MethodError("unexpected arguments"))
         s = ccall((:CDR,libR),Ptr{Void},(Ptr{Void},),s)
         ccall((:SETCAR,libR),Ptr{Void},(Ptr{Void},Ptr{Void}),s,argv)
     end
@@ -16,7 +16,7 @@ function lang(f::SEXPREC,args...;kwargs...)
         if typeof(argv) <: Symbol
             argv = sexp(argv)
         end
-        typeof(argv) <: SEXPREC || throw(MethodError("expect SEXPREC arguments"))
+        typeof(argv) <: SEXPREC || throw(MethodError("unexpected arguments"))
         s = ccall((:CDR,libR),Ptr{Void},(Ptr{Void},),s)
         ccall((:SET_TAG,libR),Ptr{Void},(Ptr{Void},Ptr{Void}),s,sexp(key))
         ccall((:SETCAR,libR),Ptr{Void},(Ptr{Void},Ptr{Void}),s,argv)
@@ -31,3 +31,7 @@ to the function to be called. It can be either a RFunction type, a SymSxp or
 a Symbol."""->
 rcall(f::SEXPREC,args...;kwargs...) = reval(lang(f,args...,kwargs...))
 rcall(f::Symbol,args...;kwargs...) = reval(lang(f,args...,kwargs...))
+
+if VERSION >= v"v0.4-"
+    Base.call(f::Union(SymSxp,LangSxp,RFunction),args...;kwargs...) = rcall(f,args...;kwargs...)
+end

--- a/src/library.jl
+++ b/src/library.jl
@@ -5,7 +5,7 @@ for w in ("while", "if", "for", "try", "return", "break",
           "global", "const", "abstract", "typealias", "type",
           "bitstype", "immutable", "ccall", "do", "module",
           "baremodule", "using", "import", "export", "importall",
-          "pymember", "false", "true")
+          "false", "true")
     push!(reserved, w) # construct Set this way for compat with Julia 0.2/0.3
 end
 

--- a/src/library.jl
+++ b/src/library.jl
@@ -13,12 +13,16 @@ function rwrap(pkg::ASCIIString,s::Symbol)
     reval("library($pkg)")
     env = rcall(symbol("as.environment"),sexp("package:$pkg"))
     !isNull(env) || error("The package has nothing!")
-    members = [(n, reval(env[symbol(n)])) for n in rcopy(rcall(:ls,env))]
-    filter!(x -> !(x[1] in reserved), members)
+    members = rcopy(rcall(:ls,env))
+    filter!(x -> !(x in reserved), members)
     m = Module(s)
-    consts = [Expr(:const, Expr(:(=), symbol(x[1]), x[2])) for x in members]
+    consts = [Expr(:const,
+                    Expr(:(=),
+                    symbol(x),
+                    lang(symbol("::"),symbol(pkg),symbol(x)))
+                ) for x in members]
     id = Expr(:(=), :__package__, pkg)
-    exports = [symbol(x[1]) for x in members]
+    exports = [symbol(x) for x in members]
     eval(m, Expr(:toplevel, consts..., Expr(:export, exports...), id))
     m
 end


### PR DESCRIPTION
as title, in v0.4.x, now it is possible to call the functions directly.
```
julia> @rimport MASS as mass

julia> rcopy(mass.ginv(sexp([1 2;3 4])))
2x2 Array{Float64,2}:
 -2.0   1.0
  1.5  -0.5
```