### PR TITLE
some fixes for v0.4.x

### DIFF
--- a/src/sexp.jl
+++ b/src/sexp.jl
@@ -227,6 +227,10 @@ for (typ,tag) in ((:Bool,10),(:Complex,15),(:Integer,13),(:Real,15))
             copy!(vec(vv),a)
             vv
         end
+    end
+end
+for (typ,tag) in ((:Bool,10),(:Complex,15),(:Integer,13),(:Real,15))
+    @eval begin
         function sexp{T<:$typ}(a::Array{T})
             rdims = sexp([size(a)...])
             vv = preserve(sexp(ccall((:Rf_allocArray,libR),Ptr{Void},(Cint,Ptr{Void}),$tag,rdims)))

--- a/src/sexp.jl
+++ b/src/sexp.jl
@@ -229,6 +229,9 @@ for (typ,tag) in ((:Bool,10),(:Complex,15),(:Integer,13),(:Real,15))
         end
     end
 end
+
+## To get rid of ambiguity, first define `sexp` for array with definite dimensions
+## then arbitrary dimensions.
 for (typ,tag) in ((:Bool,10),(:Complex,15),(:Integer,13),(:Real,15))
     @eval begin
         function sexp{T<:$typ}(a::Array{T})

--- a/src/types.jl
+++ b/src/types.jl
@@ -244,12 +244,21 @@ typealias Primitive Union(BuiltinSxp,SpecialSxp)
 
 typealias RFunction Union(ClosSxp,BuiltinSxp,SpecialSxp)
 
-@doc """
-Extract the original SEXP (pointer to an R SEXPREC)
+if VERSION < v"v0.4-"
+    @doc """
+    Extract the original SEXP (pointer to an R SEXPREC)
 
-Written as a `convert` method for convenience in `ccall`
-"""->
-Base.convert(::Type{Ptr{Void}},s::SEXPREC) = s.p
+    Written as a `convert` method for convenience in `ccall`
+    """->
+    Base.convert(::Type{Ptr{Void}},s::SEXPREC) = s.p
+else
+    @doc """
+    Extract the original SEXP (pointer to an R SEXPREC)
+
+    Written as a `unsafe_convert` method for convenience in `ccall`
+    """->
+    Base.unsafe_convert(::Type{Ptr{Void}},s::SEXPREC) = s.p
+end
 
 @doc """
 SEXPREC methods for `length` return the R length.


### PR DESCRIPTION
1. `sexp(Array{T<:Real,1},)` is ambiguous with `sexp(Array{T<:Bool,N},)`
defining `sexp(Array{Bool,1},)` first would resolve the issue

2. we have to use `unsafe_convert` to convert julia object to a pointer.