### PR TITLE
dirty fix for string array containing NAs

### DIFF
--- a/src/sexp.jl
+++ b/src/sexp.jl
@@ -144,8 +144,9 @@ Base.names(s::SEXPREC) = ByteString[rcopy(nm) for nm in getAttrib(s,namesSymbol)
 isNA(x::Complex128) = real(x) === R_NaReal && imag(x) === R_NaReal
 isNA(x::Float64) = x === R_NaReal
 isNA(x::Int32) = x == R_NaInt
-## it is wrong, but it works
-isNA(x::ByteString) = x == "NA"
+## it is still wrong, as it doesn't handle NA and 'NA' properly
+## e.g. DataArray(reval("c(NA,'NA','foo')"))
+isNA(x::ByteString) = x == rcopy(R_NaString)
 isNA(a::Array) = reshape(bitpack([isNA(aa) for aa in a]),size(a))
 
 DataArrays.DataArray(s::RVector) = (rc = rcopy(s);DataArray(rc,isNA(rc)))

--- a/src/sexp.jl
+++ b/src/sexp.jl
@@ -144,7 +144,8 @@ Base.names(s::SEXPREC) = ByteString[rcopy(nm) for nm in getAttrib(s,namesSymbol)
 isNA(x::Complex128) = real(x) === R_NaReal && imag(x) === R_NaReal
 isNA(x::Float64) = x === R_NaReal
 isNA(x::Int32) = x == R_NaInt
-isNA(x::ByteString) = x == bytestring(R_NaString)
+## it is wrong, but it works
+isNA(x::ByteString) = x == "NA"
 isNA(a::Array) = reshape(bitpack([isNA(aa) for aa in a]),size(a))
 
 DataArrays.DataArray(s::RVector) = (rc = rcopy(s);DataArray(rc,isNA(rc)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,7 @@ pqsexp = sexp(["p","q"])
 @test DataArray(reval("c(NA,1)")).na == @data([NA,1.0]).na
 @test DataArray(reval("c(NA,1+0i)")).na == @data([NA,1.0+0.0*im]).na
 @test DataArray(reval("c(NA,1L)")).na == @data([NA,one(Int32)]).na
+@test DataArray(reval("c(NA,'1')")).na == @data([NA,'1']).na
 
 langsexp = RCall.lang(:solve, sexp([1 2; 0 4]))
 @test length(langsexp) == 2


### PR DESCRIPTION
As `rcopy("NA")` returns a string `"NA"`, this dirty fix will work for most cases. But it doesn't differentiate between the real `NA` and the string `"NA"`.

Related to #32 