### PR TITLE
to be consistant with other global constants

### DIFF
--- a/src/RCall.jl
+++ b/src/RCall.jl
@@ -53,7 +53,6 @@ function __init__()
     global const Rproc = Rinstance(i)
     global const R_NaInt =  unsafe_load(cglobal((:R_NaInt,libR),Cint))
     global const R_NaReal = unsafe_load(cglobal((:R_NaReal,libR),Cdouble))
-    global const R_UnboundValue = unsafe_load(cglobal((:R_UnboundValue,libR),Ptr{Void}))
     ip = ccall((:Rf_ScalarInteger,libR),Ptr{Void},(Int32,),0)
     global const voffset = ccall((:INTEGER,libR),Ptr{Void},(Ptr{Void},),ip) - ip
     global const R_NaString = sexp(unsafe_load(cglobal((:R_NaString,libR),Ptr{Void})))
@@ -64,6 +63,7 @@ function __init__()
     global const levelsSymbol = sexp(unsafe_load(cglobal((:R_LevelsSymbol,libR),Ptr{Void})))
     global const namesSymbol = sexp(unsafe_load(cglobal((:R_NamesSymbol,libR),Ptr{Void})))
     global const nilValue = sexp(unsafe_load(cglobal((:R_NilValue,libR),Ptr{Void})))
+    global const unboundValue = sexp(unsafe_load(cglobal((:R_UnboundValue,libR),Ptr{Void})))
 end
 
     include("types.jl")                 # define the various types of SEXPREC

--- a/src/sexp.jl
+++ b/src/sexp.jl
@@ -185,7 +185,7 @@ DataFrames.DataFrame(s::Symbol) = DataFrame(reval(s))
 @doc "extract the value of symbol s in the environment e"->
 function Base.getindex(e::EnvSxp,s::Symbol)
     v = ccall((:Rf_findVarInFrame,libR),Ptr{Void},(Ptr{Void},Ptr{Void}),e,sexp(s))
-    v == R_UnboundValue && throw(BoundsError())
+    v == unboundValue.p && throw(BoundsError("s is not defined in the environment"))
     sexp(v)
 end
 


### PR DESCRIPTION
As other constants are wrapped by `sexp`, do the same for `unboundValue`.