### PR TITLE
Add IJulia plotting support

### DIFF
--- a/src/IJulia.jl
+++ b/src/IJulia.jl
@@ -1,0 +1,43 @@
+# IJulia hooks for displaying plots with RCall
+
+if isdefined(Main, :IJulia) && Main.IJulia.inited
+    import IPythonDisplay: InlineDisplay
+    
+    const pngfile = tempname()*".png"
+    const ijulia_rplot_active = [false]
+    const ijulia_rplot_dims = [480,360]
+
+    # open new png device
+    function new_rplot()
+        rcall(:png,sexp(pngfile),sexp(ijulia_rplot_dims[1]),sexp(ijulia_rplot_dims[2]))
+        ijulia_rplot_active[1] = true
+    end
+
+    # close and display png device
+    function disp_rplot()
+        if ijulia_rplot_active[1]
+            rcall(symbol("dev.off"))
+            ijulia_rplot_active[1] = false
+            if isfile(pngfile)
+                open(pngfile) do f
+                    d = read(f,Uint8,filesize(pngfile))
+                    display(InlineDisplay(),MIME("image/png"),d)
+                end
+                rm(pngfile)
+            end
+        end
+    end
+    
+    # cleanup png device on error
+    function clean_rplot()
+        if ijulia_rplot_active[1]
+            rcall(symbol("dev.off"))
+            ijulia_rplot_active[1] = false
+        end
+        isfile(pngfile) && rm(pngfile)
+    end
+    
+    Main.IJulia.push_preexecute_hook(new_rplot)
+    Main.IJulia.push_postexecute_hook(disp_rplot)
+    Main.IJulia.push_posterror_hook(clean_rplot)
+end

--- a/src/IJulia.jl
+++ b/src/IJulia.jl
@@ -2,41 +2,75 @@
 
 if isdefined(Main, :IJulia) && Main.IJulia.inited
     import IPythonDisplay: InlineDisplay
-    
-    const pngfile = tempname()*".png"
-    const ijulia_rplot_active = [false]
-    const ijulia_rplot_dims = [480,360]
+
+    const rplot_active = Bool[false]
+    const rplot_file = tempname()
+
+    const rplot_opts = Any[MIME"image/png"(),(480,360),()]
+
+    @doc """
+        Set options for R plotting with IJulia.
+
+        The first argument should be a MIME object: currently supported are 
+        * `MIME("image/png")` [default]
+        * `MIME("image/svg+xml")`
+
+        The remaining arguments are passed to the appropriate R graphics
+        device: see the relevant R help for details.
+    """->
+    function rplot_set(m::MIME,args...;kwargs...)
+        rplot_opts[1] = m
+        rplot_opts[2] = args
+        rplot_opts[3] = kwargs
+        nothing
+    end
+    rplot_set(m::MIME"image/png") = rplot_set(m,480,360)
+    rplot_set(m::MIME"image/svg+xml") = rplot_set(m,6,4)
+
+    rplot_device(m::MIME"image/png") = :png
+    rplot_device(m::MIME"image/svg+xml") = :svg
+
 
     # open new png device
     function new_rplot()
-        rcall(:png,sexp(pngfile),sexp(ijulia_rplot_dims[1]),sexp(ijulia_rplot_dims[2]))
-        ijulia_rplot_active[1] = true
+        rcall(rplot_device(rplot_opts[1]),rplot_file,rplot_opts[2]...;rplot_opts[3]...)
+        rplot_active[1] = true
+    end
+
+    function displayfile(m::MIME"image/png", f)
+        open(f) do f
+            d = read(f,UInt8,filesize(rplot_file))
+            display(InlineDisplay(),m,d)
+        end
+    end
+    function displayfile(m::MIME"image/svg+xml", f)
+        open(f) do f
+            d = readall(f)
+            display(InlineDisplay(),m,d)
+        end
     end
 
     # close and display png device
     function disp_rplot()
-        if ijulia_rplot_active[1]
+        if rplot_active[1]
             rcall(symbol("dev.off"))
-            ijulia_rplot_active[1] = false
-            if isfile(pngfile)
-                open(pngfile) do f
-                    d = read(f,Uint8,filesize(pngfile))
-                    display(InlineDisplay(),MIME("image/png"),d)
-                end
-                rm(pngfile)
+            rplot_active[1] = false
+            if isfile(rplot_file)
+                displayfile(rplot_opts[1],rplot_file)
+                rm(rplot_file)
             end
         end
     end
-    
+
     # cleanup png device on error
     function clean_rplot()
-        if ijulia_rplot_active[1]
+        if rplot_active[1]
             rcall(symbol("dev.off"))
-            ijulia_rplot_active[1] = false
+            rplot_active[1] = false
         end
-        isfile(pngfile) && rm(pngfile)
+        isfile(rplot_file) && rm(rplot_file)
     end
-    
+
     Main.IJulia.push_preexecute_hook(new_rplot)
     Main.IJulia.push_postexecute_hook(disp_rplot)
     Main.IJulia.push_posterror_hook(clean_rplot)

--- a/src/RCall.jl
+++ b/src/RCall.jl
@@ -47,7 +47,7 @@ module RCall
   In particular, globalEnv must be defined if any R expression is to be evaluated.
 """->
 function __init__()
-    argv = ["Rembed","--silent","--no-save"]
+    argv = ["R","--silent","--no-save"]
     i = ccall((:Rf_initEmbeddedR,libR),Cint,(Cint,Ptr{Ptr{Uint8}}),length(argv),argv)
     i > 0 || error("initEmbeddedR failed.  Try running Pkg.build(\"RCall\").")
     global const Rproc = Rinstance(i)
@@ -72,5 +72,6 @@ end
     include("show.jl")
     include("functions.jl")
     include("library.jl")
+    include("IJulia.jl")
 
 end # module

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -5,21 +5,13 @@ function lang(f::SEXPREC,args...;kwargs...)
     s = l.p
     ccall((:SETCAR,libR),Ptr{Void},(Ptr{Void},Ptr{Void}),s,f)
     for argv in args
-        if typeof(argv) <: Symbol
-            argv = sexp(argv)
-        end
-        typeof(argv) <: SEXPREC || throw(MethodError("unexpected arguments"))
         s = ccall((:CDR,libR),Ptr{Void},(Ptr{Void},),s)
-        ccall((:SETCAR,libR),Ptr{Void},(Ptr{Void},Ptr{Void}),s,argv)
+        ccall((:SETCAR,libR),Ptr{Void},(Ptr{Void},Ptr{Void}),s,sexp(argv))
     end
     for (key,argv) in kwargs
-        if typeof(argv) <: Symbol
-            argv = sexp(argv)
-        end
-        typeof(argv) <: SEXPREC || throw(MethodError("unexpected arguments"))
         s = ccall((:CDR,libR),Ptr{Void},(Ptr{Void},),s)
         ccall((:SET_TAG,libR),Ptr{Void},(Ptr{Void},Ptr{Void}),s,sexp(key))
-        ccall((:SETCAR,libR),Ptr{Void},(Ptr{Void},Ptr{Void}),s,argv)
+        ccall((:SETCAR,libR),Ptr{Void},(Ptr{Void},Ptr{Void}),s,sexp(argv))
     end
     l
 end
@@ -29,8 +21,8 @@ lang(s::Symbol,args...;kwargs...) = lang(sexp(s),args...;kwargs...)
 Evaluate a function in the global environment. The first argument corresponds
 to the function to be called. It can be either a RFunction type, a SymSxp or
 a Symbol."""->
-rcall(f::SEXPREC,args...;kwargs...) = reval(lang(f,args...,kwargs...))
-rcall(f::Symbol,args...;kwargs...) = reval(lang(f,args...,kwargs...))
+rcall(f::SEXPREC,args...;kwargs...) = reval(lang(f,args...;kwargs...))
+rcall(f::Symbol,args...;kwargs...) = reval(lang(f,args...;kwargs...))
 
 if VERSION >= v"v0.4-"
     Base.call(f::Union(SymSxp,LangSxp,RFunction),args...;kwargs...) = rcall(f,args...;kwargs...)

--- a/src/sexp.jl
+++ b/src/sexp.jl
@@ -5,6 +5,8 @@ const typs = [NilSxp,SymSxp,ListSxp,ClosSxp,EnvSxp,PromSxp,LangSxp,SpecialSxp,Bu
               CharSxp,LglSxp,Void,Void,IntSxp,RealSxp,CplxSxp,StrSxp,DotSxp,AnySxp,
               VecSxp,ExprSxp,BcodeSxp,ExtPtrSxp,WeakRefSxp,RawSxp,S4Sxp]
 
+sexp(s::SEXPREC) = s
+
 @doc """
 Convert a `Ptr{Void}` to the appropriate type that inherits from `SEXPREC`
 


### PR DESCRIPTION
This adds rudimentary support for IJulia. The rough idea is that before a cell is executed, a new png plot device is created. After the cell has been executed, the plot device is closed, and the resulting file is displayed.

See also discussion in #23.