### PR TITLE
throw error when converting a factor to `DataArray`

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,6 +35,9 @@ pqsexp = sexp(["p","q"])
 @test DataArray(reval("c(NA,1+0i)")).na == @data([NA,1.0+0.0*im]).na
 @test DataArray(reval("c(NA,1L)")).na == @data([NA,one(Int32)]).na
 @test DataArray(reval("c(NA,'1')")).na == @data([NA,'1']).na
+@test_throws ErrorException DataArray(reval("as.factor(c('a','a','c'))"))
+@test PooledDataArray(reval("as.factor(c('a','a','c'))")).pool == ["a","c"]
+
 
 langsexp = RCall.lang(:solve, sexp([1 2; 0 4]))
 @test length(langsexp) == 2


### PR DESCRIPTION
Now, error is thrown when converting factor to `DataArray`. One have to convert it to `PooledDataArray`. The `DataFrame` method is also changed accordingly to use `DataArray` or `PooledDataArray` adaptively.