### PR TITLE
Improve behavior of ijulia_init() on Windows

### DIFF
--- a/src/IJulia.jl
+++ b/src/IJulia.jl
@@ -67,8 +67,7 @@ function ijulia_cleanup()
 end
 
 function ijulia_init()
-    global const ijulia_file_dir = tempname()
-    mkpath(ijulia_file_dir)
+    global const ijulia_file_dir = mktempdir()
     global const ijulia_file_fmt = joinpath(ijulia_file_dir,"rij_%03d")
     Main.IJulia.push_postexecute_hook(ijulia_displayplots)
     Main.IJulia.push_posterror_hook(ijulia_cleanup)


### PR DESCRIPTION
The use of tempname() on Windows actually creates a .tmp file, and consequently the call to mkpath() fails due to the file already existing. Calling mktempdir() performs the desired operation of creating a temporary directory without this failure occurring on Windows.