### PR TITLE
fix Rinited not correct if in RStudio Server or R embedded application

### DIFF
--- a/src/RCall.jl
+++ b/src/RCall.jl
@@ -50,8 +50,21 @@ type Rinstance
 end
 
 
-function __init__()
-    Rinited = unsafe_load(cglobal((:R_NilValue,libR),Ptr{Void})) != C_NULL
+function __init__()    
+    Rinited =unsafe_load(cglobal((:R_NilValue,libR),Ptr{Void})) != C_NULL
+    #For RStudio Server or other R embedded Applications, if them emedded julia into them
+    #unsafe_load(cglobal((:R_NilValue,libR),Ptr{Void})) is null,
+    #but unsafe_load(cglobal((:R_NilValue),Ptr{Void})) is not null
+    if !Rinited
+        Rinited1=false
+        try
+         Rinited1 =unsafe_load(cglobal((:R_NilValue),Ptr{Void})) != C_NULL
+        catch
+        end
+        #if both value are false,then R not inited ,otherwise R is inited.
+        Rinited= Rinited || Rinited1
+    end
+
     if !Rinited
         # disable signal handlers
         unsafe_store!(cglobal((:R_SignalHandlers,RCall.libR),Cint),0)


### PR DESCRIPTION
now I am write rjulia2 using RCall.jl.  I found in R console when "using RCall"  everything is fine, but on RStudio Server "using RCall" will lead error.

after some digging, I found the reason:

For RStudio Server or other R embedded Applications, if they emedded julia into them. unsafe_load(cglobal((:R_NilValue,libR),Ptr{Void})) is null, but unsafe_load(cglobal((:R_NilValue),Ptr{Void})) is not null

so I create this pull request to fix this.