### PR TITLE
Evaluate R string macro inside own environment.

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,5 @@
 julia 0.4
+DataStructures
 DataArrays
 DataFrames
 @windows WinReg

--- a/src/RCall.jl
+++ b/src/RCall.jl
@@ -2,6 +2,8 @@ __precompile__()
 module RCall
 using DataFrames,DataArrays
 
+import DataStructures: OrderedDict
+
 import Base: eltype, show, convert, isascii,
     length, size, getindex, setindex!, start, next, done
 

--- a/src/iface.jl
+++ b/src/iface.jl
@@ -37,8 +37,8 @@ Evaluate an R symbol or language object (i.e. a function call) in an R
 try/catch block, returning an RObject.
 """
 reval(s, env=Const.GlobalEnv) = RObject(reval_p(sexp(s),sexp(env)))
-reval(str::AbstractString, env=Const.GlobalEnv) = reval(rparse_p(str))
-reval(sym::Symbol, env=Const.GlobalEnv) = reval(sexp(sym))
+reval(str::AbstractString, env=Const.GlobalEnv) = reval(rparse_p(str),env)
+reval(sym::Symbol, env=Const.GlobalEnv) = reval(sexp(sym),env)
 
 
 """

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -395,12 +395,18 @@ function setindex!(e::Ptr{EnvSxp},v,s)
 end
 setindex!(e::RObject{EnvSxp},v,s) = setindex!(sexp(e),v,s)
 
-"create a new environment which extends env"
+"""
+    newEnvironment([env])
+
+Create a new environment which extends environment `env` (`globalEnv` by default).
+"""
 function newEnvironment(env::Ptr{EnvSxp})
     ccall((:Rf_NewEnvironment,libR),Ptr{EnvSxp},
             (Ptr{NilSxp},Ptr{NilSxp},Ptr{EnvSxp}),sexp(Const.NilValue),sexp(Const.Const.NilValue),env)
 end
 newEnvironment(env::RObject{EnvSxp}) = newEnvironment(sexp(env))
+newEnvironment() = newEnvironment(globalEnv)
+
 
 "find namespace by name of the namespace, it is not error tolerant."
 function findNamespace(str::ByteString)


### PR DESCRIPTION
This means that we don't need to bother cleaning up after, hence fixing #107 and #109. Also, changes symbol names to be those of the underlying Julia variables, prefixed with `$`, which makes plots look nicer.