### PR TITLE
symbol(...) => Symbol(...)

### DIFF
--- a/src/callback.jl
+++ b/src/callback.jl
@@ -8,7 +8,7 @@ function makeNativeSymbol(fptr::Ptr{Void})
     # Rdynpriv.h
     rexfn = ccall((:R_MakeExternalPtrFn,libR), ExtPtrSxpPtr,
                      (Ptr{Void}, Ptr{Void}, Ptr{Void}),
-                     fptr, sexp(symbol("native symbol")), sexp(Const.NilValue))
+                     fptr, sexp(Symbol("native symbol")), sexp(Const.NilValue))
     setAttrib!(rexfn, Const.ClassSymbol, sexp("NativeSymbol"))
     preserve(rexfn)
     rexfn
@@ -121,7 +121,7 @@ Constructs the following R code
 
 """
 function sexp(::Type{ClosSxp}, f)
-    body = protect(rlang_p(symbol(".External"),
+    body = protect(rlang_p(Symbol(".External"),
                            juliaCallback,
                            sexp(ExtPtrSxp,f),
                            Const.DotsSymbol))

--- a/src/convert-base.jl
+++ b/src/convert-base.jl
@@ -45,7 +45,7 @@ sexp(::Type{SymSxp}, s::Symbol) = sexp(SymSxp,string(s))
 "Generic function for constructing Sxps from Julia objects."
 sexp(s::Symbol) = sexp(SymSxp,s)
 
-rcopy(::Type{Symbol},ss::SymSxp) = symbol(rcopy(AbstractString,ss))
+rcopy(::Type{Symbol},ss::SymSxp) = Symbol(rcopy(AbstractString,ss))
 rcopy(::Type{AbstractString},ss::SymSxp) = rcopy(AbstractString,ss.name)
 rcopy{T<:Union{Symbol,AbstractString}}(::Type{T},s::Ptr{SymSxp}) =
     rcopy(T,unsafe_load(s))
@@ -66,7 +66,7 @@ sexp(::Type{CharSxp},sym::Symbol) = sexp(CharSxp,string(sym))
 
 
 rcopy{T<:AbstractString}(::Type{T},s::CharSxpPtr) = convert(T, bytestring(unsafe_vec(s)))
-rcopy(::Type{Symbol},s::CharSxpPtr) = symbol(rcopy(AbstractString,s))
+rcopy(::Type{Symbol},s::CharSxpPtr) = Symbol(rcopy(AbstractString,s))
 rcopy(::Type{Int}, s::CharSxpPtr) = parse(Int, rcopy(s))
 
 "Create a `StrSxp` from an `AbstractString`"

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -35,5 +35,5 @@ Base.call{S<:Union{SymSxp,LangSxp,PromSxp,FunctionSxp}}(f::RObject{S},args...;kw
 Returns a variable named "str". Useful for passing keyword arguments containing dots.
 """
 macro var_str(str)
-    esc(symbol(str))
+    esc(Symbol(str))
 end

--- a/src/iface.jl
+++ b/src/iface.jl
@@ -93,7 +93,7 @@ function rprint{S<:Sxp}(io::IO, s::Ptr{S})
         else
             # Rf_PrintValueRec not found on unix!?
             # ccall((:Rf_PrintValueRec,libR),Void,(Ptr{S},Ptr{EnvSxp}),s, Const.GlobalEnv)
-            reval(rlang_p(Const.BaseNamespace[symbol("print.default")], :x),env)
+            reval(rlang_p(Const.BaseNamespace[Symbol("print.default")], :x),env)
         end
         env[:x] = Const.NilValue
         write(io,takebuf_string(printBuffer))

--- a/src/library.jl
+++ b/src/library.jl
@@ -16,11 +16,11 @@ function rwrap(pkg::ASCIIString,s::Symbol)
     m = Module(s)
     consts = [Expr(:const,
                     Expr(:(=),
-                    symbol(x),
-                    rcall(symbol("::"),symbol(pkg),symbol(x)))
+                    Symbol(x),
+                    rcall(Symbol("::"),Symbol(pkg),Symbol(x)))
                 ) for x in members]
     id = Expr(:(=), :__package__, pkg)
-    exports = [symbol(x) for x in members]
+    exports = [Symbol(x) for x in members]
     s in exports && error("$pkg has a function with the same name as $(pkg), use `@rimport $pkg as ...` instead.")
     eval(m, Expr(:toplevel, consts..., Expr(:export, exports...), id, Expr(:(=), :__exports__, exports)))
     m
@@ -62,11 +62,11 @@ macro rlibrary(x)
         members = rcopy("ls('package:$($pkg)')")
         filter!(x -> !(x in reserved), members)
         for m in members
-            sym = symbol(m)
+            sym = Symbol(m)
             eval(current_module(), Expr(
                     :(=),
                     sym,
-                    Expr(:call, :rcall, QuoteNode(symbol("::")), QuoteNode($pkg), QuoteNode(sym))
+                    Expr(:call, :rcall, QuoteNode(Symbol("::")), QuoteNode($pkg), QuoteNode(sym))
                 )
             )
         end

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -1,7 +1,7 @@
 import Base: +, -, *, /, ^
 
-+(x::RObject, y::RObject) = rcall(symbol("+"), x, y)
--(x::RObject, y::RObject) = rcall(symbol("-"), x, y)
-*(x::RObject, y::RObject) = rcall(symbol("*"), x, y)
-/(x::RObject, y::RObject) = rcall(symbol("/"), x, y)
-^(x::RObject, y::RObject) = rcall(symbol("^"), x, y)
++(x::RObject, y::RObject) = rcall(Symbol("+"), x, y)
+-(x::RObject, y::RObject) = rcall(Symbol("-"), x, y)
+*(x::RObject, y::RObject) = rcall(Symbol("*"), x, y)
+/(x::RObject, y::RObject) = rcall(Symbol("/"), x, y)
+^(x::RObject, y::RObject) = rcall(Symbol("^"), x, y)

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -18,7 +18,7 @@ langsexp[2] = RObject([1 2; 0 0])
 globalEnv[:x] = RObject([1,2,3])
 @test rcopy(globalEnv[:x]) == [1,2,3]
 globalEnv[:y] = RObject([4,5,6])
-@test rcopy(rcall(symbol("+"),:x,:y)) == [5,7,9]
+@test rcopy(rcall(Symbol("+"),:x,:y)) == [5,7,9]
 
 x = 1:10
 @rput x
@@ -64,7 +64,7 @@ RCall.rgui_init()
 f = tempname()
 rcall(:png,f)
 rcall(:plot,1:10)
-rcall(symbol("dev.off"))
+rcall(Symbol("dev.off"))
 @test isfile(f)
 @test !RCall.rgui_start(true)
 @test_throws ErrorException RCall.rgui_start()

--- a/test/rstr.jl
+++ b/test/rstr.jl
@@ -5,5 +5,5 @@ using RCall
 iris = rcopy(:iris)
 model =  R"lm(Sepal.Length ~ Sepal.Width,data=$iris)"
 @test rcopy(RCall.getClass(model)) == "lm"
-@test isapprox(rcopy(R"sum($iris$Sepal.Length)"), sum(iris[symbol("Sepal.Length")]), rtol=4*eps())
+@test isapprox(rcopy(R"sum($iris$Sepal.Length)"), sum(iris[Symbol("Sepal.Length")]), rtol=4*eps())
 


### PR DESCRIPTION
Passes tests under v0.4 and v0.5 and does not produce warnings about `symbol => Symbol` under v0.5

@simonbyrne Can you take a look and pull the trigger if this seems okay?