### PR TITLE
catch error by R_ParseContextLast and R_ParseContext

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -60,7 +60,7 @@ values from R via the return value.
 """
 macro R_str(script)
     script, symdict, status, msg = render_rscript(script)
-    status != 1 && error(msg)
+    status != 1 && error("RCall.jl: $msg")
 
     blk_ld = Expr(:block)
     for (rsym, expr) in symdict

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -62,21 +62,22 @@ macro R_str(script)
     script, symdict, status, msg = render_rscript(script)
     status != 1 && error("RCall.jl: $msg")
 
-    blk_ld = Expr(:block)
-    for (rsym, expr) in symdict
-        push!(blk_ld.args,:(env[$rsym] = $(esc(expr))))
-    end
-    quote
-        let env = protect(newEnvironment())
-            globalEnv["#JL"] = env
-            try
-                $blk_ld
-            finally
-                unprotect(1)
-            end
-            nothing
+    if length(symdict) > 0
+        blk_ld = Expr(:block)
+        for (rsym, expr) in symdict
+            push!(blk_ld.args,:(env[$rsym] = $(esc(expr))))
         end
-        reval($script, globalEnv)
+        return quote
+            let env = reval_p(rparse_p("`#JL` <- new.env()"))
+                $blk_ld
+                nothing
+            end
+            reval($script, globalEnv)
+        end
+    else
+        return quote
+            reval($script, globalEnv)
+        end
     end
 end
 

--- a/src/render.jl
+++ b/src/render.jl
@@ -2,7 +2,7 @@
 Render an inline R script, substituting invalid "\$" signs for Julia symbols
 """
 function render_rscript(script::Compat.String)
-    symdict = OrderedDict{Compat.ASCIIString,Any}()
+    symdict = OrderedDict{Compat.String,Any}()
     sf = protect(rcall_p(:srcfile,"xx"))
     local status
     local msg
@@ -15,41 +15,16 @@ function render_rscript(script::Compat.String)
                 break
             end
 
-            if !isascii(script)
-                msg = "Unicode R scripts not supported, due to\n    https://bugs.r-project.org/bugzilla3/show_bug.cgi?id=16524"
-                break
-            end
+            # there is a bug in the R parser https://bugs.r-project.org/bugzilla3/show_bug.cgi?id=16524
+            # R_ParseContextLast and R_ParseContext are not documentated, but they seem to work
 
-            parsedata = protect(rcall_p(:getParseData, sf))
-            n = length(parsedata[1])
-
-            lineno = parsedata[1][n]
-            charno = parsedata[2][n] # this is the character no., not byte number
-
-            c = rcopy(Compat.UTF8String, parsedata[9][n])
-            unprotect(1)
-
-            c != "\$" && break
-
-            # skip to string location
-            i = start(script)
-            for j = 1:lineno-1
-                i = search(script,'\n',i)
-                i = nextind(script,i)
-            end
-            for j = 1:charno-1
-                i = nextind(script,i)
-            end
-
-            # assuming no unicode, see
-            # https://bugs.r-project.org/bugzilla3/show_bug.cgi?id=16524
-            i_stop = prevind(script,i)
-
-            c,i = next(script,i)
-
+            # the position of the error byte
+            b = Int(unsafe_load(cglobal((:R_ParseContextLast, RCall.libR), Int32)))
+            # it is unsafe to use `unsafe_string` if the last byte is a part of a unicode,
+            c = Char(unsafe_load(cglobal((:R_ParseContext, RCall.libR), UInt8)+b))
             c != '\$' && break
 
-            expr,i = parse(script,i,greedy=false)
+            expr,i = parse(script,b+1,greedy=false)
 
             if isa(expr,Symbol)
                 sym = "$expr"
@@ -61,12 +36,12 @@ function render_rscript(script::Compat.String)
                 end
             end
             symdict[sym] = expr
-            script = string(script[1:i_stop],"`#JL`\$`",sym,'`',script[i:end])
+            script = string(script[1:b-1],"`#JL`\$`",sym,'`',script[i:end])
         end
-
     finally
-        unprotect(1)
+        unprotect(1) #sf
     end
+
     if status == 1
         return script, symdict, status, msg
     else

--- a/src/render.jl
+++ b/src/render.jl
@@ -3,43 +3,49 @@ Render an inline R script, substituting invalid "\$" signs for Julia symbols
 """
 function render_rscript(script::Compat.String)
     symdict = OrderedDict{Compat.String,Any}()
-    sf = protect(rcall_p(:srcfile,"xx"))
     local status
-    local msg
+    local msg = ""
+    while true
+        val, status, msg = parseVector(sexp(script))
 
-    try
-        while true
-            val, status, msg = parseVector(sexp(script), sf)
-
-            if status == 1 || status == 2
-                break
-            end
-
-            # there is a bug in the R parser https://bugs.r-project.org/bugzilla3/show_bug.cgi?id=16524
-            # R_ParseContextLast and R_ParseContext are not documentated, but they seem to work
-
-            # the position of the error byte
-            b = Int(unsafe_load(cglobal((:R_ParseContextLast, RCall.libR), Int32)))
-            # it is unsafe to use `unsafe_string` if the last byte is a part of a unicode,
-            c = Char(unsafe_load(cglobal((:R_ParseContext, RCall.libR), UInt8)+b))
-            c != '\$' && break
-
-            expr,i = parse(script,b+1,greedy=false)
-
-            if isa(expr,Symbol)
-                sym = "$expr"
-            else
-                sym = "($expr)"
-                # if an expression has already appeared, we generate a new symbol so it will be evaluated twice (e.g. `R"$(rand(10)) == $(rand(10))"`)
-                if haskey(symdict, sym)
-                    sym *= "##$k"
-                end
-            end
-            symdict[sym] = expr
-            script = string(script[1:b-1],"`#JL`\$`",sym,'`',script[i:end])
+        if status == 1 || status == 2
+            break
         end
-    finally
-        unprotect(1) #sf
+
+        # there is a bug in the R parser https://bugs.r-project.org/bugzilla3/show_bug.cgi?id=16524
+        # R_ParseContextLast and R_ParseContext are not documentated, but they seem to work
+
+        # the position of the error byte
+        b = Int(unsafe_load(cglobal((:R_ParseContextLast, RCall.libR), Int32)))
+        # it is unsafe to use `unsafe_string` if the last byte is a part of a unicode,
+        c = Char(unsafe_load(cglobal((:R_ParseContext, RCall.libR), UInt8)+b))
+        c != '\$' && break
+
+        ast,i = parse(script,b+1,greedy=false,raise=false)
+
+        if isa(ast,Symbol)
+            sym = "$ast"
+        elseif isa(ast, Expr) && !(ast.head == :error || ast.head == :continue || ast.head == :incomplete)
+            sym = "($ast)"
+            # if an expression has already appeared, we generate a new symbol so it will be evaluated twice (e.g. `R"$(rand(10)) == $(rand(10))"`)
+            if haskey(symdict, sym)
+                sym *= "##$k"
+            end
+        elseif isa(ast, Expr) && (ast.head == :error || ast.head == :continue)
+            status = 3
+            msg = ast.args[1]
+            break
+        elseif isa(ast, Expr) && ast.head == :incomplete
+            status = 2
+            msg = ast.args[1]
+            break
+        else
+            status = 3
+            msg = "unknown render error"
+            break
+        end
+        symdict[sym] = ast
+        script = string(script[1:b-1],"`#JL`\$`",sym,'`',script[i:end])
     end
 
     if status == 1

--- a/test/rstr.jl
+++ b/test/rstr.jl
@@ -12,6 +12,10 @@ using RCall
 
 @test RCall.render_rscript("x = ]")[4] == "unexpected ']'"
 
+@test RCall.render_rscript("x = \$(begin")[3] == 2
+
+@test RCall.render_rscript("x = \$(begin)")[3] == 3
+
 @test RCall.render_rscript("x = ")[4] == "unexpected end of input"
 
 @test rcopy(R"sum($[7,1,3])") == sum([7,1,3])

--- a/test/rstr.jl
+++ b/test/rstr.jl
@@ -8,7 +8,7 @@ using RCall
 
 @test RCall.render_rscript("x = \$(rand(1))")[3] == 1
 
-@test contains(RCall.render_rscript("x = 'α'; x = \$y")[4], "not supported")
+@test RCall.render_rscript("x = \$α")[2]["α"] == :α
 
 @test RCall.render_rscript("x = ]")[4] == "unexpected ']'"
 


### PR DESCRIPTION
use the undocumented `R_ParseContextLast` and `R_ParseContext` to detect parse error.

close #132 